### PR TITLE
Add list of eqLogic children

### DIFF
--- a/core/ajax/sshmanager.ajax.php
+++ b/core/ajax/sshmanager.ajax.php
@@ -42,6 +42,19 @@ try {
         $commands = sshmanager::getTemplateCommands();
         ajax::success($commands);
     }
+  
+    if (init('action') == 'getUsedBy') {
+        $return = '';
+        $usedBy = sshmanager::customUsedBy('eqLogic', init('eqLogic_id'));
+        foreach ($usedBy as $usedByEqLogic) {
+            if ($usedByEqLogic->getIsEnable() != 1) {
+                $return .= '<a href="' . $usedByEqLogic->getLinkToConfiguration() . '" class="btn btn-xs btn-info">' . $usedByEqLogic->getHumanName() . '</a><br/>';
+            } else {
+                $return .= '<a href="' . $usedByEqLogic->getLinkToConfiguration() . '" class="btn btn-xs btn-primary">' . $usedByEqLogic->getHumanName() . '</a><br/>';
+            }
+        }
+        ajax::success($return);
+    }
 
     throw new Exception(__('Aucune méthode correspondante à : ', __FILE__) . init('action'));
     /*     * *********Catch exeption*************** */

--- a/core/ajax/sshmanager.ajax.php
+++ b/core/ajax/sshmanager.ajax.php
@@ -47,10 +47,12 @@ try {
         $return = '';
         $usedBy = sshmanager::customUsedBy('eqLogic', init('eqLogic_id'));
         foreach ($usedBy as $usedByEqLogic) {
+            $plugin = plugin::byId($usedByEqLogic->getEqType_name());
+		    $return .= '<a href="' . $plugin->getLinkToConfiguration() . '" class="btn btn-xs btn-info"><img class="img-responsive" style="width : 18px;display:inline-block;" src="' . $plugin->getPathImgIcon() . '" /> ' . $plugin->getName(). ' </a>';
             if ($usedByEqLogic->getIsEnable() != 1) {
-                $return .= '<a href="' . $usedByEqLogic->getLinkToConfiguration() . '" class="btn btn-xs btn-info">' . $usedByEqLogic->getHumanName() . '</a><br/>';
+                $return .= '<a href="' . $usedByEqLogic->getLinkToConfiguration() . '" class="btn btn-xs btn-info">' . $usedByEqLogic->getHumanName(true) . '</a><br/>';
             } else {
-                $return .= '<a href="' . $usedByEqLogic->getLinkToConfiguration() . '" class="btn btn-xs btn-primary">' . $usedByEqLogic->getHumanName() . '</a><br/>';
+                $return .= '<a href="' . $usedByEqLogic->getLinkToConfiguration() . '" class="btn btn-xs btn-primary">' . $usedByEqLogic->getHumanName(true) . '</a><br/>';
             }
         }
         ajax::success($return);

--- a/core/class/sshmanager.class.php
+++ b/core/class/sshmanager.class.php
@@ -147,6 +147,12 @@ class sshmanager extends eqLogic {
         return $CommunityInfo;
     }
 
+    public static function customUsedBy($_type, $_id) {
+        if ($_type == 'eqLogic') {
+            return array_merge(eqLogic::searchConfiguration(array('#eqLogic' . $_id . '#', '"host_id":"' . $_id . '"')));
+        }
+    }
+
     // Methods used by client plugins
 
     public static function getRemoteHosts() {

--- a/desktop/js/sshmanager.js
+++ b/desktop/js/sshmanager.js
@@ -207,7 +207,7 @@ document.getElementById('div_pageContainer').addEventListener("change", function
 });
 
 function printEqLogic(_eqLogic) {
-  $.ajax({
+  domUtils.ajax({
     type: 'POST',
     url: 'plugins/sshmanager/core/ajax/sshmanager.ajax.php',
     data: {

--- a/desktop/js/sshmanager.js
+++ b/desktop/js/sshmanager.js
@@ -206,6 +206,34 @@ document.getElementById('div_pageContainer').addEventListener("change", function
 	}
 });
 
+function printEqLogic(_eqLogic) {
+  $.ajax({
+    type: 'POST',
+    url: 'plugins/sshmanager/core/ajax/sshmanager.ajax.php',
+    data: {
+      action: 'getUsedBy',
+      eqLogic_id: _eqLogic.id
+    },
+    dataType: 'json',
+    error: function (error) {
+      jeedomUtils.showAlert({ message: error.message, level: 'danger' })
+    },
+    success: function (data) {
+      if (data.state != 'ok') {
+        jeedomUtils.showAlert({
+          title: "SSH Manager	- UsedBy",
+          message: "Error :: Retrieving children eqLogic !",
+          level: 'warning',
+          emptyBefore: false
+        });
+        return;
+      }
+      document.getElementById('div_eqLogicList').innerHTML = data.result;
+    }
+  });
+
+}
+
 document.getElementById('div_pageContainer').addEventListener("click", function(event) {
 	if (event.target.classList.contains("btnTemplateCmds")) {
 		jeeDialog.dialog({

--- a/desktop/php/sshmanager.php
+++ b/desktop/php/sshmanager.php
@@ -188,6 +188,11 @@ $eqLogics = eqLogic::byType($plugin->getId());
                                     <textarea class="form-control eqLogicAttr" rows="5" data-l1key="comment"></textarea>
                                 </div>
                             </div>
+                            <div class="form-group">
+                                <label class="col-sm-4 control-label">{{Equipement(s) enfants}}</label>
+                                <div class="col-sm-6" id="div_eqLogicList">
+                                </div>
+                              </div>
                         </div>
                     </fieldset>
                 </form>


### PR DESCRIPTION
Add a list of children (with configuration link) using the sshmanager plugin in eqLogic configuration page.

<img width="502" alt="Capture d’écran 2024-12-31 à 10 58 25" src="https://github.com/user-attachments/assets/06d06a93-edc0-42ac-8076-cb50c1605d6e" />


Detection only works with children plugins using `data-l2key="host_id"`, as you wrote in your example.
```
<div class="form-group">
    <label class="col-sm-4 control-label help" data-help="{{Choisissez un hôte dans la liste ou créez un nouveau}}">{{Hôte}}</label>
    <div class="col-sm-3">
        <div class="input-group">
            <select class="eqLogicAttr form-control roundedLeft sshmanagerHelper" data-helper="list" data-l1key="configuration" data-l2key="host_id">

            </select>
            <span class="input-group-btn">
                <a class="btn btn-default cursor roundedRight sshmanagerHelper" data-helper="add" title="{{Ajouter un nouvel hôte}}">
                    <i class="fas fa-plus-circle"></i>
                </a>
            </span>
        </div>
    </div>
</div>
```