### PR TITLE
v1.2.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -125,16 +125,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.48",
+            "version": "3.0.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "64065a5679c50acb886e82c07aa139b0f757bb89"
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/64065a5679c50acb886e82c07aa139b0f757bb89",
-                "reference": "64065a5679c50acb886e82c07aa139b0f757bb89",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
                 "shasum": ""
             },
             "require": {
@@ -215,7 +215,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.48"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
             },
             "funding": [
                 {
@@ -231,7 +231,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-15T11:51:42+00:00"
+            "time": "2026-03-19T02:57:58+00:00"
         }
     ],
     "packages-dev": [],

--- a/core/class/sshmanager.class.php
+++ b/core/class/sshmanager.class.php
@@ -703,9 +703,9 @@ class sshmanager extends eqLogic {
 
             if (!empty($result)) {
                 $result = trim($result);
-                //TODO: '\n' should be escaped from $result before logging
+                $resultOneLine = str_replace(["\r\n", "\r", "\n"], '\\n', $result);
                 log::add(__CLASS__, 'debug', '[' . $this->getName() . '] ' . (!empty($cmdName) ? $cmdName : 'Cmd') . ' :: ' . str_replace("\r\n", "\\r\\n", $command));
-                log::add(__CLASS__, 'debug', '[' . $this->getName() . '] ' . (!empty($cmdName) ? $cmdName : 'Cmd') . ' Result :: ' . $result);
+                log::add(__CLASS__, 'debug', '[' . $this->getName() . '] ' . (!empty($cmdName) ? $cmdName : 'Cmd') . ' Result :: ' . $resultOneLine);
             } else {
                 log::add(__CLASS__, 'debug', '[' . $this->getName() . '] ' . (!empty($cmdName) ? $cmdName : 'Cmd') . ' :: ' . str_replace("\r\n", "\\r\\n", $command));
                 log::add(__CLASS__, 'debug', '[' . $this->getName() . '] ' . (!empty($cmdName) ? $cmdName : 'Cmd') . ' :: Empty Result');

--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "sshmanager",
 	"name": "SSH Manager",
-	"pluginVersion": "1.2.1",
+	"pluginVersion": "1.2.2",
 	"description": {
 		"fr_FR": "Plugin permettant d'ajouter (manuellement ou à partir de templates) des commandes SSH à executer (manuellement ou automatiquement) sur des équipements distants, et pouvant également être utilisé par d'autres plugin comme passerelle SSH.",
 		"en_US": "Plugin for adding (manually or from templates) SSH commands to be executed (manually or automatically) on remote devices, and which can also be used by other plugins as an SSH gateway.",

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -125,17 +125,17 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.48",
-            "version_normalized": "3.0.48.0",
+            "version": "3.0.50",
+            "version_normalized": "3.0.50.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "64065a5679c50acb886e82c07aa139b0f757bb89"
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/64065a5679c50acb886e82c07aa139b0f757bb89",
-                "reference": "64065a5679c50acb886e82c07aa139b0f757bb89",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
                 "shasum": ""
             },
             "require": {
@@ -153,7 +153,7 @@
                 "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
                 "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
             },
-            "time": "2025-12-15T11:51:42+00:00",
+            "time": "2026-03-19T02:57:58+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -218,7 +218,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.48"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
             },
             "funding": [
                 {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -38,9 +38,9 @@
             'dev_requirement' => false,
         ),
         'phpseclib/phpseclib' => array(
-            'pretty_version' => '3.0.48',
-            'version' => '3.0.48.0',
-            'reference' => '64065a5679c50acb886e82c07aa139b0f757bb89',
+            'pretty_version' => '3.0.50',
+            'version' => '3.0.50.0',
+            'reference' => 'aa6ad8321ed103dc3624fb600a25b66ebf78ec7b',
             'type' => 'library',
             'install_path' => __DIR__ . '/../phpseclib/phpseclib',
             'aliases' => array(),

--- a/vendor/phpseclib/phpseclib/phpseclib/Common/Functions/Strings.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Common/Functions/Strings.php
@@ -356,9 +356,11 @@ abstract class Strings
                 // from http://graphics.stanford.edu/~seander/bithacks.html#ReverseByteWith32Bits
                 $p1 = ($b * 0x0802) & 0x22110;
                 $p2 = ($b * 0x8020) & 0x88440;
-                $r .= chr(
-                    (($p1 | $p2) * 0x10101) >> 16
-                );
+                $temp = ($p1 | $p2) * 0x10101;
+                if (is_float($temp)) {
+                    $temp = (int) fmod($temp, 0x7FFFFFFF);
+                }
+                $r .= chr(($temp >> 16) & 0xFF);
             }
         }
         return $r;

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/Blowfish.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/Blowfish.php
@@ -448,8 +448,8 @@ class Blowfish extends BlockCipher
     protected static function initialize_static_variables()
     {
         if (is_float(self::$sbox[0x200])) {
-            self::$sbox = array_map('intval', self::$sbox);
-            self::$parray = array_map('intval', self::$parray);
+            self::$sbox = array_map([self::class, 'safe_intval'], self::$sbox);
+            self::$parray = array_map([self::class, 'safe_intval'], self::$parray);
         }
 
         parent::initialize_static_variables();

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/ChaCha20.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/ChaCha20.php
@@ -279,10 +279,10 @@ class ChaCha20 extends Salsa20
         // xor'ing and rotation are all on the same line so i'm keeping it on the same
         // line here as well
         // @codingStandardsIgnoreStart
-        $a+= $b; $d = self::leftRotate(intval($d) ^ intval($a), 16);
-        $c+= $d; $b = self::leftRotate(intval($b) ^ intval($c), 12);
-        $a+= $b; $d = self::leftRotate(intval($d) ^ intval($a), 8);
-        $c+= $d; $b = self::leftRotate(intval($b) ^ intval($c), 7);
+        $a+= $b; $d = self::leftRotate(self::safe_intval($d) ^ self::safe_intval($a), 16);
+        $c+= $d; $b = self::leftRotate(self::safe_intval($b) ^ self::safe_intval($c), 12);
+        $a+= $b; $d = self::leftRotate(self::safe_intval($d) ^ self::safe_intval($a), 8);
+        $c+= $d; $b = self::leftRotate(self::safe_intval($b) ^ self::safe_intval($c), 7);
         // @codingStandardsIgnoreEnd
     }
 
@@ -357,424 +357,424 @@ class ChaCha20 extends Salsa20
 
         // @codingStandardsIgnoreStart
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
 
         // columnRound
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 16);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 12);
-        $x0+= $x4; $x12 = self::leftRotate(intval($x12) ^ intval($x0), 8);
-        $x8+= $x12; $x4 = self::leftRotate(intval($x4) ^ intval($x8), 7);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 16);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 12);
+        $x0+= $x4; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x0), 8);
+        $x8+= $x12; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x8), 7);
 
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 16);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 12);
-        $x1+= $x5; $x13 = self::leftRotate(intval($x13) ^ intval($x1), 8);
-        $x9+= $x13; $x5 = self::leftRotate(intval($x5) ^ intval($x9), 7);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 16);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 12);
+        $x1+= $x5; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x1), 8);
+        $x9+= $x13; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x9), 7);
 
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 16);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 12);
-        $x2+= $x6; $x14 = self::leftRotate(intval($x14) ^ intval($x2), 8);
-        $x10+= $x14; $x6 = self::leftRotate(intval($x6) ^ intval($x10), 7);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 16);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 12);
+        $x2+= $x6; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x2), 8);
+        $x10+= $x14; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x10), 7);
 
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 16);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 12);
-        $x3+= $x7; $x15 = self::leftRotate(intval($x15) ^ intval($x3), 8);
-        $x11+= $x15; $x7 = self::leftRotate(intval($x7) ^ intval($x11), 7);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 16);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 12);
+        $x3+= $x7; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x3), 8);
+        $x11+= $x15; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x11), 7);
 
         // rowRound
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 16);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 12);
-        $x0+= $x5; $x15 = self::leftRotate(intval($x15) ^ intval($x0), 8);
-        $x10+= $x15; $x5 = self::leftRotate(intval($x5) ^ intval($x10), 7);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 16);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 12);
+        $x0+= $x5; $x15 = self::leftRotate(self::safe_intval($x15) ^ self::safe_intval($x0), 8);
+        $x10+= $x15; $x5 = self::leftRotate(self::safe_intval($x5) ^ self::safe_intval($x10), 7);
 
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 16);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 12);
-        $x1+= $x6; $x12 = self::leftRotate(intval($x12) ^ intval($x1), 8);
-        $x11+= $x12; $x6 = self::leftRotate(intval($x6) ^ intval($x11), 7);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 16);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 12);
+        $x1+= $x6; $x12 = self::leftRotate(self::safe_intval($x12) ^ self::safe_intval($x1), 8);
+        $x11+= $x12; $x6 = self::leftRotate(self::safe_intval($x6) ^ self::safe_intval($x11), 7);
 
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 16);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 12);
-        $x2+= $x7; $x13 = self::leftRotate(intval($x13) ^ intval($x2), 8);
-        $x8+= $x13; $x7 = self::leftRotate(intval($x7) ^ intval($x8), 7);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 16);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 12);
+        $x2+= $x7; $x13 = self::leftRotate(self::safe_intval($x13) ^ self::safe_intval($x2), 8);
+        $x8+= $x13; $x7 = self::leftRotate(self::safe_intval($x7) ^ self::safe_intval($x8), 7);
 
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 16);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 12);
-        $x3+= $x4; $x14 = self::leftRotate(intval($x14) ^ intval($x3), 8);
-        $x9+= $x14; $x4 = self::leftRotate(intval($x4) ^ intval($x9), 7);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 16);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 12);
+        $x3+= $x4; $x14 = self::leftRotate(self::safe_intval($x14) ^ self::safe_intval($x3), 8);
+        $x9+= $x14; $x4 = self::leftRotate(self::safe_intval($x4) ^ self::safe_intval($x9), 7);
         // @codingStandardsIgnoreEnd
 
         $x0 += $z0;
@@ -794,6 +794,6 @@ class ChaCha20 extends Salsa20
         $x14 += $z14;
         $x15 += $z15;
 
-        return pack('V*', $x0, $x1, $x2, $x3, $x4, $x5, $x6, $x7, $x8, $x9, $x10, $x11, $x12, $x13, $x14, $x15);
+        return pack('V*', self::safe_intval($x0), self::safe_intval($x1), self::safe_intval($x2), self::safe_intval($x3), self::safe_intval($x4), self::safe_intval($x5), self::safe_intval($x6), self::safe_intval($x7), self::safe_intval($x8), self::safe_intval($x9), self::safe_intval($x10), self::safe_intval($x11), self::safe_intval($x12), self::safe_intval($x13), self::safe_intval($x14), self::safe_intval($x15));
     }
 }

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/Common/Formats/Keys/OpenSSH.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/Common/Formats/Keys/OpenSSH.php
@@ -118,7 +118,7 @@ abstract class OpenSSH
             return compact('type', 'publicKey', 'paddedKey');
         }
 
-        $parts = explode(' ', $key, 3);
+        $parts = preg_split("#[\t ]+#", $key);
 
         if (!isset($parts[1])) {
             $key = base64_decode($parts[0]);

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/Common/SymmetricKey.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/Common/SymmetricKey.php
@@ -666,6 +666,11 @@ abstract class SymmetricKey
     {
         if (!isset(self::$use_reg_intval)) {
             switch (true) {
+                // PHP 8.5, per https://www.php.net/manual/en/migration85.incompatible.php, now emits a warning
+                // "when casting floats (or strings that look like floats) to int if they cannot be represented as one"
+                case PHP_VERSION_ID >= 80500 && PHP_INT_SIZE == 4:
+                    self::$use_reg_intval = false;
+                    break;
                 // PHP_OS & "\xDF\xDF\xDF" == strtoupper(substr(PHP_OS, 0, 3)), but a lot faster
                 case (PHP_OS & "\xDF\xDF\xDF") === 'WIN':
                 case !function_exists('php_uname'):
@@ -2591,7 +2596,7 @@ abstract class SymmetricKey
 
         $length = ord($text[strlen($text) - 1]);
 
-        if (!$length || $length > $this->block_size) {
+        if (!$length | ($length > $this->block_size)) {
             throw new BadDecryptionException("The ciphertext has an invalid padding length ($length) compared to the block size ({$this->block_size})");
         }
 

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/DES.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/DES.php
@@ -673,14 +673,14 @@ class DES extends BlockCipher
     {
         static $sbox1, $sbox2, $sbox3, $sbox4, $sbox5, $sbox6, $sbox7, $sbox8, $shuffleip, $shuffleinvip;
         if (!$sbox1) {
-            $sbox1 = array_map('intval', self::$sbox1);
-            $sbox2 = array_map('intval', self::$sbox2);
-            $sbox3 = array_map('intval', self::$sbox3);
-            $sbox4 = array_map('intval', self::$sbox4);
-            $sbox5 = array_map('intval', self::$sbox5);
-            $sbox6 = array_map('intval', self::$sbox6);
-            $sbox7 = array_map('intval', self::$sbox7);
-            $sbox8 = array_map('intval', self::$sbox8);
+            $sbox1 = array_map([self::class, 'safe_intval'], self::$sbox1);
+            $sbox2 = array_map([self::class, 'safe_intval'], self::$sbox2);
+            $sbox3 = array_map([self::class, 'safe_intval'], self::$sbox3);
+            $sbox4 = array_map([self::class, 'safe_intval'], self::$sbox4);
+            $sbox5 = array_map([self::class, 'safe_intval'], self::$sbox5);
+            $sbox6 = array_map([self::class, 'safe_intval'], self::$sbox6);
+            $sbox7 = array_map([self::class, 'safe_intval'], self::$sbox7);
+            $sbox8 = array_map([self::class, 'safe_intval'], self::$sbox8);
             /* Merge $shuffle with $[inv]ipmap */
             for ($i = 0; $i < 256; ++$i) {
                 $shuffleip[]    =  self::$shuffle[self::$ipmap[$i]];
@@ -1243,9 +1243,9 @@ class DES extends BlockCipher
                       $pc2mapd3[($d >>  8) & 0xFF] | $pc2mapd4[ $d        & 0xFF];
 
                 // Reorder: odd bytes/even bytes. Push the result in key schedule.
-                $val1 = ( $cp        & intval(0xFF000000)) | (($cp <<  8) & 0x00FF0000) |
+                $val1 = ( $cp        & self::safe_intval(0xFF000000)) | (($cp <<  8) & 0x00FF0000) |
                         (($dp >> 16) & 0x0000FF00) | (($dp >>  8) & 0x000000FF);
-                $val2 = (($cp <<  8) & intval(0xFF000000)) | (($cp << 16) & 0x00FF0000) |
+                $val2 = (($cp <<  8) & self::safe_intval(0xFF000000)) | (($cp << 16) & 0x00FF0000) |
                         (($dp >>  8) & 0x0000FF00) | ( $dp        & 0x000000FF);
                 $keys[$des_round][self::ENCRYPT][       ] = $val1;
                 $keys[$des_round][self::DECRYPT][$ki - 1] = $val1;
@@ -1292,14 +1292,14 @@ class DES extends BlockCipher
 
         $init_crypt = 'static $sbox1, $sbox2, $sbox3, $sbox4, $sbox5, $sbox6, $sbox7, $sbox8, $shuffleip, $shuffleinvip;
             if (!$sbox1) {
-                $sbox1 = array_map("intval", self::$sbox1);
-                $sbox2 = array_map("intval", self::$sbox2);
-                $sbox3 = array_map("intval", self::$sbox3);
-                $sbox4 = array_map("intval", self::$sbox4);
-                $sbox5 = array_map("intval", self::$sbox5);
-                $sbox6 = array_map("intval", self::$sbox6);
-                $sbox7 = array_map("intval", self::$sbox7);
-                $sbox8 = array_map("intval", self::$sbox8);'
+                $sbox1 = array_map("self::safe_intval", self::$sbox1);
+                $sbox2 = array_map("self::safe_intval", self::$sbox2);
+                $sbox3 = array_map("self::safe_intval", self::$sbox3);
+                $sbox4 = array_map("self::safe_intval", self::$sbox4);
+                $sbox5 = array_map("self::safe_intval", self::$sbox5);
+                $sbox6 = array_map("self::safe_intval", self::$sbox6);
+                $sbox7 = array_map("self::safe_intval", self::$sbox7);
+                $sbox8 = array_map("self::safe_intval", self::$sbox8);'
                 /* Merge $shuffle with $[inv]ipmap */ . '
                 for ($i = 0; $i < 256; ++$i) {
                     $shuffleip[]    =  self::$shuffle[self::$ipmap[$i]];

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/DSA/Formats/Keys/PKCS1.php
@@ -66,10 +66,22 @@ abstract class PKCS1 extends Progenitor
             return $key;
         }
 
-        $key = ASN1::asn1map($decoded[0], Maps\DSAPublicKey::MAP);
-        if (is_array($key)) {
-            return $key;
-        }
+        // PKCS1 DSA public keys are not supported by phpseclib since they can't be used to do
+        // anything on their own. in order to verify a signature with DSA you need p, q, g and y.
+        // a PKCS1 DSA public key only has y. to verify a signature with a PKCS1 DSA public key
+        // you'd also need to load a PKCS1 DSA parameters file separately. like you'd need to
+        // load two files instead of just one. there's no other key format that phpseclib supports
+        // that has that requirement so building it in for PKCS1 DSA public keys seems excessive.
+        //
+        // the whole thing would be rather like an RSA public key having the modulo live in
+        // a separate file than the exponent.
+        //
+        // this isn't an issue for PKCS8 DSA public keys because those keys have the parameters
+        // included. eg. \phpseclib3\File\ASN1\Maps\SubjectPublicKeyInfo has "algorithm" and
+        // "subjectPublicKey" and "algorithm", in turn, has "algorithm" and "parameters". y
+        // is saved as "subjectPublicKey" and p, q and g are saved as "parameters".
+
+        //$key = ASN1::asn1map($decoded[0], Maps\DSAPublicKey::MAP);
 
         throw new \RuntimeException('Unable to perform ASN1 mapping');
     }

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/PrivateKey.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/PrivateKey.php
@@ -216,7 +216,7 @@ final class PrivateKey extends RSA implements Common\PrivateKey
         $db = $ps . chr(1) . $salt;
         $dbMask = $this->mgf1($h, $emLen - $this->hLen - 1); // ie. stlren($db)
         $maskedDB = $db ^ $dbMask;
-        $maskedDB[0] = ~chr(0xFF << ($emBits & 7)) & $maskedDB[0];
+        $maskedDB[0] = ~chr(256 - (1 << ($emBits & 7))) & $maskedDB[0];
         $em = $maskedDB . $h . chr(0xBC);
 
         return $em;

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/PublicKey.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/RSA/PublicKey.php
@@ -241,13 +241,13 @@ final class PublicKey extends RSA implements Common\PublicKey
 
         $maskedDB = substr($em, 0, -$this->hLen - 1);
         $h = substr($em, -$this->hLen - 1, $this->hLen);
-        $temp = chr(0xFF << ($emBits & 7));
+        $temp = chr(256 - (1 << ($emBits & 7)));
         if ((~$maskedDB[0] & $temp) != $temp) {
             return false;
         }
         $dbMask = $this->mgf1($h, $emLen - $this->hLen - 1);
         $db = $maskedDB ^ $dbMask;
-        $db[0] = ~chr(0xFF << ($emBits & 7)) & $db[0];
+        $db[0] = ~chr(256 - (1 << ($emBits & 7))) & $db[0];
         $temp = $emLen - $this->hLen - $sLen - 2;
         if (substr($db, 0, $temp) != str_repeat(chr(0), $temp) || ord($db[$temp]) != 1) {
             return false;

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/Rijndael.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/Rijndael.php
@@ -378,7 +378,7 @@ class Rijndael extends BlockCipher
         $k = $c[2];
         $l = $c[3];
         while ($i < $Nb) {
-            $temp[$i] = ($state[$i] & intval(0xFF000000)) ^
+            $temp[$i] = ($state[$i] & (PHP_INT_SIZE == 8 ? 0xFF000000 : -16777216)) ^
                         ($state[$j] & 0x00FF0000) ^
                         ($state[$k] & 0x0000FF00) ^
                         ($state[$l] & 0x000000FF) ^
@@ -452,7 +452,7 @@ class Rijndael extends BlockCipher
         $l = $Nb - $c[3];
 
         while ($i < $Nb) {
-            $word = ($state[$i] & intval(0xFF000000)) |
+            $word = ($state[$i] & (PHP_INT_SIZE == 8 ? 0xFF000000 : -16777216)) |
                     ($state[$j] & 0x00FF0000) |
                     ($state[$k] & 0x0000FF00) |
                     ($state[$l] & 0x000000FF);
@@ -528,7 +528,7 @@ class Rijndael extends BlockCipher
                 0x97000000, 0x35000000, 0x6A000000, 0xD4000000, 0xB3000000,
                 0x7D000000, 0xFA000000, 0xEF000000, 0xC5000000, 0x91000000
             ];
-            $rcon = array_map('intval', $rcon);
+            $rcon = array_map([self::class, 'safe_intval'], $rcon);
         }
 
         if (isset($this->kl['key']) && $this->key === $this->kl['key'] && $this->key_length === $this->kl['key_length'] && $this->block_size === $this->kl['block_size']) {
@@ -568,7 +568,9 @@ class Rijndael extends BlockCipher
                 // on a 32-bit machine, it's 32-bits, and on a 64-bit machine, it's 64-bits. on a 32-bit machine,
                 // 0xFFFFFFFF << 8 == 0xFFFFFF00, but on a 64-bit machine, it equals 0xFFFFFFFF00. as such, doing 'and'
                 // with 0xFFFFFFFF (or 0xFFFFFF00) on a 32-bit machine is unnecessary, but on a 64-bit machine, it is.
-                $temp = (($temp << 8) & intval(0xFFFFFF00)) | (($temp >> 24) & 0x000000FF); // rotWord
+                $temp = PHP_INT_SIZE == 8 ? // rotWord
+                    (($temp << 8) & 0xFFFFFF00) | (($temp >> 24) & 0x000000FF) :
+                    ($temp << 8) | (($temp >> 24) & 0x000000FF);
                 $temp = $this->subWord($temp) ^ $rcon[$i / $this->Nk];
             } elseif ($this->Nk > 6 && $i % $this->Nk == 4) {
                 $temp = $this->subWord($temp);
@@ -659,7 +661,7 @@ class Rijndael extends BlockCipher
             // according to <http://csrc.nist.gov/archive/aes/rijndael/Rijndael-ammended.pdf#page=19> (section 5.2.1),
             // precomputed tables can be used in the mixColumns phase. in that example, they're assigned t0...t3, so
             // those are the names we'll use.
-            $t3 = array_map('intval', [
+            $t3 = array_map([self::class, 'safe_intval'], [
                 // with array_map('intval', ...) we ensure we have only int's and not
                 // some slower floats converted by php automatically on high values
                 0x6363A5C6, 0x7C7C84F8, 0x777799EE, 0x7B7B8DF6, 0xF2F20DFF, 0x6B6BBDD6, 0x6F6FB1DE, 0xC5C55491,
@@ -697,9 +699,9 @@ class Rijndael extends BlockCipher
             ]);
 
             foreach ($t3 as $t3i) {
-                $t0[] = (($t3i << 24) & intval(0xFF000000)) | (($t3i >>  8) & 0x00FFFFFF);
-                $t1[] = (($t3i << 16) & intval(0xFFFF0000)) | (($t3i >> 16) & 0x0000FFFF);
-                $t2[] = (($t3i <<  8) & intval(0xFFFFFF00)) | (($t3i >> 24) & 0x000000FF);
+                $t0[] = (($t3i << 24) & self::safe_intval(0xFF000000)) | (($t3i >>  8) & 0x00FFFFFF);
+                $t1[] = (($t3i << 16) & self::safe_intval(0xFFFF0000)) | (($t3i >> 16) & 0x0000FFFF);
+                $t2[] = (($t3i <<  8) & self::safe_intval(0xFFFFFF00)) | (($t3i >> 24) & 0x000000FF);
             }
 
             $tables = [
@@ -744,7 +746,7 @@ class Rijndael extends BlockCipher
     {
         static $tables;
         if (empty($tables)) {
-            $dt3 = array_map('intval', [
+            $dt3 = array_map([self::class, 'safe_intval'], [
                 0xF4A75051, 0x4165537E, 0x17A4C31A, 0x275E963A, 0xAB6BCB3B, 0x9D45F11F, 0xFA58ABAC, 0xE303934B,
                 0x30FA5520, 0x766DF6AD, 0xCC769188, 0x024C25F5, 0xE5D7FC4F, 0x2ACBD7C5, 0x35448026, 0x62A38FB5,
                 0xB15A49DE, 0xBA1B6725, 0xEA0E9845, 0xFEC0E15D, 0x2F7502C3, 0x4CF01281, 0x4697A38D, 0xD3F9C66B,
@@ -779,11 +781,19 @@ class Rijndael extends BlockCipher
                 0xA8017139, 0x0CB3DE08, 0xB4E49CD8, 0x56C19064, 0xCB84617B, 0x32B670D5, 0x6C5C7448, 0xB85742D0
             ]);
 
-            foreach ($dt3 as $dt3i) {
-                $dt0[] = (($dt3i << 24) & intval(0xFF000000)) | (($dt3i >>  8) & 0x00FFFFFF);
-                $dt1[] = (($dt3i << 16) & intval(0xFFFF0000)) | (($dt3i >> 16) & 0x0000FFFF);
-                $dt2[] = (($dt3i <<  8) & intval(0xFFFFFF00)) | (($dt3i >> 24) & 0x000000FF);
-            };
+            if (PHP_INT_SIZE === 8) {
+                foreach ($dt3 as $dt3i) {
+                    $dt0[] = (($dt3i << 24) & 0xFF000000) | (($dt3i >>  8) & 0x00FFFFFF);
+                    $dt1[] = (($dt3i << 16) & 0xFFFF0000) | (($dt3i >> 16) & 0x0000FFFF);
+                    $dt2[] = (($dt3i <<  8) & 0xFFFFFF00) | (($dt3i >> 24) & 0x000000FF);
+                };
+            } else {
+                foreach ($dt3 as $dt3i) {
+                    $dt0[] = ($dt3i << 24) | (($dt3i >>  8) & 0x00FFFFFF);
+                    $dt1[] = ($dt3i << 16) | (($dt3i >> 16) & 0x0000FFFF);
+                    $dt2[] = ($dt3i <<  8) | (($dt3i >> 24) & 0x000000FF);
+                };
+            }
 
             $tables = [
                 // The Precomputed inverse mixColumns tables dt0 - dt3
@@ -879,7 +889,7 @@ class Rijndael extends BlockCipher
         $encrypt_block .= '$in = pack("N*"' . "\n";
         for ($i = 0; $i < $Nb; ++$i) {
             $encrypt_block .= ',
-                ($' . $e . $i                  . ' & ' . ((int)0xFF000000) . ') ^
+                ($' . $e . $i                   . ' & ' . (PHP_INT_SIZE == 8 ? 0xFF000000 : -16777216).') ^
                 ($' . $e . (($i + $c[1]) % $Nb) . ' &         0x00FF0000   ) ^
                 ($' . $e . (($i + $c[2]) % $Nb) . ' &         0x0000FF00   ) ^
                 ($' . $e . (($i + $c[3]) % $Nb) . ' &         0x000000FF   ) ^
@@ -935,7 +945,7 @@ class Rijndael extends BlockCipher
         $decrypt_block .= '$in = pack("N*"' . "\n";
         for ($i = 0; $i < $Nb; ++$i) {
             $decrypt_block .= ',
-                ($' . $e . $i .                        ' & ' . ((int)0xFF000000) . ') ^
+                ($' . $e . $i .                         ' & ' . (PHP_INT_SIZE == 8 ? 0xFF000000 : -16777216).') ^
                 ($' . $e . (($Nb + $i - $c[1]) % $Nb) . ' &         0x00FF0000   ) ^
                 ($' . $e . (($Nb + $i - $c[2]) % $Nb) . ' &         0x0000FF00   ) ^
                 ($' . $e . (($Nb + $i - $c[3]) % $Nb) . ' &         0x000000FF   ) ^

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/Salsa20.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/Salsa20.php
@@ -411,7 +411,7 @@ class Salsa20 extends StreamCipher
             $r1 &= 0xFFFFFFFF;
             $r2 = ($x & 0xFFFFFFFF) >> (32 - $n);
         } else {
-            $x = (int) $x;
+            $x = self::safe_intval($x);
             $r1 = $x << $n;
             $r2 = $x >> (32 - $n);
             $r2 &= (1 << $n) - 1;
@@ -482,7 +482,7 @@ class Salsa20 extends StreamCipher
         }
 
         for ($i = 1; $i <= 16; $i++) {
-            $x[$i] += $z[$i];
+            $x[$i] = self::safe_intval($x[$i] + $z[$i]);
         }
 
         return pack('V*', ...$x);

--- a/vendor/phpseclib/phpseclib/phpseclib/Crypt/Twofish.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Crypt/Twofish.php
@@ -373,12 +373,12 @@ class Twofish extends BlockCipher
     protected static function initialize_static_variables()
     {
         if (is_float(self::$m3[0])) {
-            self::$m0 = array_map('intval', self::$m0);
-            self::$m1 = array_map('intval', self::$m1);
-            self::$m2 = array_map('intval', self::$m2);
-            self::$m3 = array_map('intval', self::$m3);
-            self::$q0 = array_map('intval', self::$q0);
-            self::$q1 = array_map('intval', self::$q1);
+            self::$m0 = array_map([self::class, 'safe_intval'], self::$m0);
+            self::$m1 = array_map([self::class, 'safe_intval'], self::$m1);
+            self::$m2 = array_map([self::class, 'safe_intval'], self::$m2);
+            self::$m3 = array_map([self::class, 'safe_intval'], self::$m3);
+            self::$q0 = array_map([self::class, 'safe_intval'], self::$q0);
+            self::$q1 = array_map([self::class, 'safe_intval'], self::$q1);
         }
 
         parent::initialize_static_variables();

--- a/vendor/phpseclib/phpseclib/phpseclib/File/X509.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/File/X509.php
@@ -315,6 +315,7 @@ class X509
                 'id-at-uniqueIdentifier' => '2.5.4.45',
                 'id-at-role' => '2.5.4.72',
                 'id-at-postalAddress' => '2.5.4.16',
+                'id-at-organizationIdentifier' => '2.5.4.97',
                 'jurisdictionOfIncorporationCountryName' => '1.3.6.1.4.1.311.60.2.1.3',
                 'jurisdictionOfIncorporationStateOrProvinceName' => '1.3.6.1.4.1.311.60.2.1.2',
                 'jurisdictionLocalityName' => '1.3.6.1.4.1.311.60.2.1.1',
@@ -1612,6 +1613,9 @@ class X509
             case 'organizationalunitname':
             case 'ou':
                 return 'id-at-organizationalUnitName';
+            case 'id-at-organizationidentifier':
+            case 'organizationIdentifier':
+                return 'id-at-organizationIdentifier';
             case 'id-at-pseudonym':
             case 'pseudonym':
                 return 'id-at-pseudonym';

--- a/vendor/phpseclib/phpseclib/phpseclib/Math/BigInteger/Engines/Engine.php
+++ b/vendor/phpseclib/phpseclib/phpseclib/Math/BigInteger/Engines/Engine.php
@@ -549,8 +549,8 @@ abstract class Engine implements \JsonSerializable
 
         $carry = 0;
         for ($i = strlen($x) - 1; $i >= 0; --$i) {
-            $temp = ord($x[$i]) << $shift | $carry;
-            $x[$i] = chr($temp);
+            $temp = (ord($x[$i]) << $shift) | $carry;
+            $x[$i] = chr($temp & 0xFF);
             $carry = $temp >> 8;
         }
         $carry = ($carry != 0) ? chr($carry) : '';


### PR DESCRIPTION
This pull request makes a small but important improvement to the logging in the `sshmanager` plugin, ensuring that command results are logged on a single line for better readability. The plugin version is also incremented to reflect this change.

Logging improvement:

* Updated the `internalExecuteCmd` method in `sshmanager.class.php` to escape newline characters in command results before logging, so results appear as a single line in logs.

Version update:

* Bumped the plugin version from `1.2.1` to `1.2.2` in `info.json` to reflect the new logging behavior.