### PR TITLE
v1.2.3

### DIFF
--- a/plugin_info/info.json
+++ b/plugin_info/info.json
@@ -1,7 +1,7 @@
 {
 	"id": "sshmanager",
 	"name": "SSH Manager",
-	"pluginVersion": "1.2.2",
+	"pluginVersion": "1.2.3",
 	"description": {
 		"fr_FR": "Plugin permettant d'ajouter (manuellement ou à partir de templates) des commandes SSH à executer (manuellement ou automatiquement) sur des équipements distants, et pouvant également être utilisé par d'autres plugin comme passerelle SSH.",
 		"en_US": "Plugin for adding (manually or from templates) SSH commands to be executed (manually or automatically) on remote devices, and which can also be used by other plugins as an SSH gateway.",

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -62,35 +62,28 @@ function sshmanager_update() {
     }
 
     /* Ménage dans les répertoires du plugin si besoin */
+    $pluginDir = dirname(__DIR__);
     try {
-        $dirToDelete = array(
-            /* __DIR__ . '/../ressources' */
+        $pathsToRemove = array(
+            // Accepte fichiers ET répertoires (rm -rf) — ajouter ici les chemins à supprimer à chaque mise à jour
         );
-        
-        $filesToDelete = array(
-            /* __DIR__ . '/../plugin_info/packages.json' */
-        );
-
-        foreach ($dirToDelete as $dir) {
-            log::add('sshmanager', 'debug', '[DIR-CHECK] Vérification de la présence du répertoire ' . $dir);
-            if (file_exists($dir)) {
-                shell_exec('sudo rm -rf ' . $dir);
-                log::add('sshmanager', 'debug', '[DIR-CHECK_OK] Le répertoire ' . $dir . ' a bien été effacé.');
+        foreach ($pathsToRemove as $path) {
+            log::add('sshmanager', 'debug', '[CLEANUP] Vérification du chemin : ' . $path);
+            if (file_exists($path)) {
+                $output = array();
+                $returnVar = 0;
+                exec('rm -rf ' . escapeshellarg($path) . ' 2>&1', $output, $returnVar);
+                if ($returnVar !== 0) {
+                    log::add('sshmanager', 'warning', '[CLEANUP_KO] Echec suppression "' . $path . '" (Code: ' . $returnVar . ') : ' . implode(' ', $output));
+                } else {
+                    log::add('sshmanager', 'info', '[CLEANUP_OK] Chemin supprimé : ' . $path);
+                }
             } else {
-                log::add('sshmanager', 'debug', '[DIR-CHECK_NA] Répertoire ' . $dir . ' non trouvé. Aucune action requise.');
-            }
-        }
-        foreach ($filesToDelete as $file) {
-            log::add('sshmanager', 'debug', '[FILE-CHECK] Vérification de la présence du fichier : ' . $file);
-            if (file_exists($file)) {
-                shell_exec('sudo rm -f ' . $file);
-                log::add('sshmanager', 'debug', '[FILE-CHECK_OK] Le fichier  ' . $file . ' a bien été effacé.');
-            } else {
-                log::add('sshmanager', 'debug', '[FILE-CHECK_NA] Fichier ' . $file . ' non trouvé. Aucune action requise.');
+                log::add('sshmanager', 'debug', '[CLEANUP_NA] Chemin non trouvé, aucune action : ' . $path);
             }
         }
     } catch (Exception $e) {
-        log::add('sshmanager', 'debug', '[DIR-FILE-CHECK_KO] Exception :: ' . $e->getMessage());
+        log::add('sshmanager', 'warning', '[CLEANUP_KO] Erreur lors du nettoyage : ' . $e->getMessage());
     }
 }
 

--- a/plugin_info/install.php
+++ b/plugin_info/install.php
@@ -67,21 +67,27 @@ function sshmanager_update() {
         $pathsToRemove = array(
             // Accepte fichiers ET répertoires (rm -rf) — ajouter ici les chemins à supprimer à chaque mise à jour
         );
+        $cleanupRemoved = 0;
+        $cleanupErrors = 0;
         foreach ($pathsToRemove as $path) {
-            log::add('sshmanager', 'debug', '[CLEANUP] Vérification du chemin : ' . $path);
             if (file_exists($path)) {
                 $output = array();
                 $returnVar = 0;
                 exec('rm -rf ' . escapeshellarg($path) . ' 2>&1', $output, $returnVar);
                 if ($returnVar !== 0) {
+                    $cleanupErrors++;
                     log::add('sshmanager', 'warning', '[CLEANUP_KO] Echec suppression "' . $path . '" (Code: ' . $returnVar . ') : ' . implode(' ', $output));
                 } else {
+                    $cleanupRemoved++;
                     log::add('sshmanager', 'info', '[CLEANUP_OK] Chemin supprimé : ' . $path);
                 }
-            } else {
-                log::add('sshmanager', 'debug', '[CLEANUP_NA] Chemin non trouvé, aucune action : ' . $path);
             }
         }
+        $cleanupSummary = count($pathsToRemove) . ' chemin(s) vérifié(s), ' . $cleanupRemoved . ' supprimé(s)';
+        if ($cleanupErrors > 0) {
+            $cleanupSummary .= ', ' . $cleanupErrors . ' erreur(s)';
+        }
+        log::add('sshmanager', 'debug', '[CLEANUP] ' . $cleanupSummary);
     } catch (Exception $e) {
         log::add('sshmanager', 'warning', '[CLEANUP_KO] Erreur lors du nettoyage : ' . $e->getMessage());
     }


### PR DESCRIPTION
This pull request updates the `sshmanager` plugin, focusing mainly on improving the cleanup process during plugin updates. The most significant changes are a refactor of the directory and file cleanup logic in the update script and a version bump.

**Cleanup process improvements:**

* Refactored the cleanup logic in `install.php` to use a unified `$pathsToRemove` array for both files and directories, simplifying maintenance and future updates. The code now uses `exec` with `escapeshellarg` for safer deletion, and logs detailed summaries of actions and errors.
* Improved error handling and logging: any issues during cleanup are now logged as warnings, and a summary of the cleanup operation is always logged.

**Versioning:**

* Bumped the plugin version from `1.2.2` to `1.2.3` in `info.json` to reflect the changes.